### PR TITLE
RUBY-888 add xxe routes and specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,6 @@
 GIT
   remote: https://github.com/Contrast-Security-OSS/vulneruby
-  revision: 9b1ffe6bd53f2ab645302c7afab78e7d8f4b2e4b
-  branch: RUBY-887-ssrf
+  revision: d4b777b2fb630cdd6ff073d4eeb34175397db334
   specs:
     vulneruby (0.1.1)
       rake (~> 12.0)
@@ -207,4 +206,4 @@ DEPENDENCIES
   vulneruby_engine!
 
 BUNDLED WITH
-   2.1.2
+   2.1.4

--- a/app/controllers/vulneruby_engine/xxe_controller.rb
+++ b/app/controllers/vulneruby_engine/xxe_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require('vulneruby/trigger/xxe')
+
+module VulnerubyEngine
+  # Entry point for the XXE tests
+  class XxeController < ApplicationController
+    def index
+      render('layouts/vulneruby_engine/xxe/index')
+    end
+
+    def run
+      @result = Vulneruby::Trigger::Xxe.run_nokogiri
+      render('layouts/vulneruby_engine/xxe/run')
+    end
+  end
+end

--- a/app/controllers/vulneruby_engine/xxe_controller.rb
+++ b/app/controllers/vulneruby_engine/xxe_controller.rb
@@ -10,7 +10,7 @@ module VulnerubyEngine
     end
 
     def run
-      @result = Vulneruby::Trigger::Xxe.run_nokogiri
+      @result = Vulneruby::Trigger::Xxe.run_nokogiri(params[:entity])
       render('layouts/vulneruby_engine/xxe/run')
     end
   end

--- a/app/views/application/_navigation.html.erb
+++ b/app/views/application/_navigation.html.erb
@@ -15,6 +15,9 @@
         <ul class="menu-list">
           <li><a href=<%= ssrf_path %>>SSRF</a></li>
         </ul>
+        <ul class="menu-list">
+          <li><a href=<%= xxe_path %>>XXE</a></li>
+        </ul>
       </div>
     </div>
   </aside>

--- a/app/views/layouts/vulneruby_engine/xxe/index.html.erb
+++ b/app/views/layouts/vulneruby_engine/xxe/index.html.erb
@@ -1,0 +1,13 @@
+<div>
+  <h1>XXE</h1>
+  <form action=<%= xxe_path %> method="post">
+    <div class="field has-addons">
+      <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
+      <div class="control">
+        <button class="button is-info" action="submit">
+          Load Unsafe XML
+        </button>
+      </div>
+    </div>
+  </form>
+</div>

--- a/app/views/layouts/vulneruby_engine/xxe/index.html.erb
+++ b/app/views/layouts/vulneruby_engine/xxe/index.html.erb
@@ -2,10 +2,13 @@
   <h1>XXE</h1>
   <form action=<%= xxe_path %> method="post">
     <div class="field has-addons">
+      <div class="control">
+        <input class="input" type="text" name="entity" placeholder="nokogiri">
+      </div>
       <%= hidden_field_tag :authenticity_token, form_authenticity_token %>
       <div class="control">
         <button class="button is-info" action="submit">
-          Load Unsafe XML
+          Submit
         </button>
       </div>
     </div>

--- a/app/views/layouts/vulneruby_engine/xxe/run.html.erb
+++ b/app/views/layouts/vulneruby_engine/xxe/run.html.erb
@@ -1,0 +1,3 @@
+The loaded xml was:
+
+<%= render 'application/result' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ VulnerubyEngine::Engine.routes.draw do
   RULES = %w[
     cmdi
     ssrf
+    xxe
   ].freeze
 
   RULES.each do |rule|

--- a/spec/app/controllers/vulneruby_engine/xxe_controller_spec.rb
+++ b/spec/app/controllers/vulneruby_engine/xxe_controller_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+RSpec.describe('XXE Controller', type: :request) do
+  describe 'GET /xxe' do
+    it 'renders the xxe input page' do
+      get '/vulneruby_engine/xxe'
+      expect(response).to(render_template(:index))
+    end
+  end
+
+  describe 'POST /xxe' do
+    it 'renders the xxe result page' do
+      post '/vulneruby_engine/xxe'
+      expect(response).to(render_template(:run))
+      expect(response.body).to(include('xml'))
+    end
+  end
+end

--- a/spec/app/controllers/vulneruby_engine/xxe_controller_spec.rb
+++ b/spec/app/controllers/vulneruby_engine/xxe_controller_spec.rb
@@ -10,9 +10,9 @@ RSpec.describe('XXE Controller', type: :request) do
 
   describe 'POST /xxe' do
     it 'renders the xxe result page' do
-      post '/vulneruby_engine/xxe'
+      post '/vulneruby_engine/xxe', params: { entity: 'nokogiri' }
       expect(response).to(render_template(:run))
-      expect(response.body).to(include('xml'))
+      expect(response.body).to(include('nokogiri'))
     end
   end
 end


### PR DESCRIPTION
This adds xxe routes & specs - you can test this locally by adding: `branch: RUBY-888-xxe` to the Gemfile where we specify the `vulneruby` dependency