### PR TITLE
RUBY-965 update deserialization controller to use base64 encoded string

### DIFF
--- a/app/controllers/vulneruby_engine/untrusted_deserialization_controller.rb
+++ b/app/controllers/vulneruby_engine/untrusted_deserialization_controller.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'base64'
 
 require('vulneruby/trigger/untrusted_deserialization')
 
@@ -6,12 +7,12 @@ module VulnerubyEngine
   # Entry point for the CMD Injection tests
   class UntrustedDeserializationController < ApplicationController
     def index
-      @example = "'#{ Marshal.dump('foobar') }'"
+      @example = Base64.strict_encode64(Marshal.dump('foobar'))
       render('layouts/vulneruby_engine/untrusted_deserialization/index')
     end
 
     def run
-      @data = params[:data]
+      @data = Base64.strict_decode64(params[:data])
       @result = Vulneruby::Trigger::UntrustedDeserialization.
           run_marshal_load(@data)
       render('layouts/vulneruby_engine/untrusted_deserialization/run')

--- a/app/views/layouts/vulneruby_engine/untrusted_deserialization/index.html.erb
+++ b/app/views/layouts/vulneruby_engine/untrusted_deserialization/index.html.erb
@@ -1,7 +1,7 @@
 <div>
   <h1>Untrusted Deserialization</h1>
   <form action=<%= untrusted_deserialization_path %> method="post">
-    <p>Example marshal string: <%= raw @example %></p>
+    <p>Example base64 encoded marshal string: <%= raw @example %></p>
     <div class="field has-addons">
       <div class="control">
         <input class="input" type="text" name="data" placeholder="Marshal string">

--- a/spec/integration/requests.json
+++ b/spec/integration/requests.json
@@ -35,7 +35,7 @@
   {
     "navigation_name": "Untrusted Deserialization",
     "input_field_name": "data",
-    "value": "\u0004\bI\"\u000Bfoobar\u0006:\u0006ET"
+    "value": "BAhJIgtmb29iYXIGOgZFVA=="
   },
   {
     "navigation_name": "Unsafe Code Execution",

--- a/spec/integration/test.json
+++ b/spec/integration/test.json
@@ -102,7 +102,6 @@
     "trigger_method": "eval"
   },
   {
-    "ticket": "https://contrast.atlassian.net/browse/RUBY-965",
     "rule_id": "untrusted-deserialization",
     "dataflow": true,
     "trigger_class": "Marshal",


### PR DESCRIPTION
Updates to base deserialization easier to trigger(no need for all the special chars since it relies on base64 encoded strings now)