### PR TITLE
RUBY-1002 Library Discovery and Observation

### DIFF
--- a/docker/Dockerfile_passenger
+++ b/docker/Dockerfile_passenger
@@ -46,4 +46,4 @@ RUN bundle exec rails db:migrate
 ENV PASSENGER_TEST=true
 ENV PORT=$PORT_ARG
 
-CMD CONTRAST__APPLICATION__NAME=$(cat /tmp/app_name.txt) bundle exec rails s -p $PORT
+CMD CONTRAST_CONFIG_PATH=/app/contrast_security.yaml CONTRAST__APPLICATION__NAME=$(cat /tmp/app_name.txt) bundle exec rails s -p $PORT

--- a/spec/integration/messages/attack/attack_test_case.rb
+++ b/spec/integration/messages/attack/attack_test_case.rb
@@ -1,66 +1,81 @@
 # frozen_string_literal: true
 
-class AttackTestCase
+require_relative '../test_case'
+
+# This tests covers the runtime discovery of Attacks in the Protect feature set
+# of the Contrast Agent.
+class AttackTestCase < TestCase
   def self.msg_source
     'activity_application'
   end
 
   def initialize data
+    super
     @rule_id = data['rule_id']
     @input_name = data['input_name']
     @input_value = data['input_value']
-    @ticket = data['ticket']
-    @found = false
   end
 
-  def found?
-    !!@found
+  def name
+    @rule_id
   end
 
-  def has_ticket?
-    !!@ticket
-  end
-
-  def passed?
-    found? || has_ticket?
-  end
-
-  def to_s
-    "#{ @rule_id } - #{ found? } #{ " - Ticket: #{ @ticket }" if has_ticket? }"
-  end
-
+  # Determines if at least one message from our msg_source matches this
+  # testcase.
+  #
+  # @param reported_messages [Array<Hash>] an array of JSON representing the
+  #   Activity Application reports sent by the Contrast Service during this
+  #   test run.
   def assert! reported_messages
     @found = match?(reported_messages)
   end
 
+  private
+
+  # The messages match if any has the same rule id and a sample with the same
+  # input name and value.
+  #
+  # @param reported_messages [Hash] JSON representing an Activity Application
+  #   reports sent by the Contrast Service during this test run.
+  # @return [Boolean]
   def match? reported_messages
     reported_messages&.each do |activity_message|
       attackers = activity_message.fetch('defend', nil)&.fetch('attackers', nil)
       next unless attackers
 
-      attackers.each do |attacker_message|
-        return true if attack_match?(attacker_message)
+      attackers.each do |reported_attacker|
+        return true if attack_match?(reported_attacker)
       end
     end
     false
   end
 
-  private
-
-  def attack_match? attacker_message
-    messages = attacker_message.fetch('protectionRules', nil)&.fetch(@rule_id, nil)
+  # A reported attack matches this test if it has the same rule id and a sample
+  # with the same input name and value.
+  #
+  # @param reported_attacker [Hash] JSON representing an entity from the
+  #   `defend.attackers` field of an Activity Application report
+  # @return [Boolean]
+  def attack_match? reported_attacker
+    messages = reported_attacker.fetch('protectionRules', nil)&.fetch(@rule_id, nil)
     return unless messages
 
     probes = messages['ineffective']&.fetch('samples', nil)
     exploits = messages['exploited']&.fetch('samples', nil)
-    reported?(probes) || reported?(exploits)
+    sample_match?(probes) || sample_match?(exploits)
   end
 
-  def reported? samples
-    return false unless samples
+  # A reported sample matches this test if it has the same input name and value
+  # as this test.
+  #
+  # @param reported_samples [Hash] JSON representing an entity from the
+  #   `defend.attackers.*.samples` field of an Activity Application report
+  # @return [Boolean]
+  def sample_match? reported_samples
+    return false unless reported_samples
 
-    samples.each do |sample|
-      input = sample['input']
+    reported_samples.each do |reported_sample|
+      input = reported_sample['input']
       return true if input['name'] == @input_name && input['value'] == @input_value
     end
     false

--- a/spec/integration/messages/library_discovery/library_discovery_test_case.rb
+++ b/spec/integration/messages/library_discovery/library_discovery_test_case.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require_relative '../test_case'
+
+# This tests covers the startup discovery of Library Discovery in the Inventory
+# feature set of the Contrast Agent.
+class LibraryDiscoveryTestCase < TestCase
+  def self.msg_source
+    'update_application'
+  end
+
+  def initialize data
+    super
+    @hash = data['hash']
+    @gem = data['file']
+    @version = data['version']
+    @file_count = data['classCount']
+    @url = data['url']
+  end
+
+  def name
+    @hash
+  end
+
+  # Determines if at least one message from our msg_source matches this
+  # testcase.
+  #
+  # @param reported_messages [Array<Hash>] an array of JSON representing the
+  #   Update Application reports sent by the Contrast Service during this test
+  #   run.
+  def assert! reported_messages
+    @found = match?(reported_messages)
+  end
+
+  private
+
+  # A reported message matches this test if it has the same hash, gem, url
+  # version, and file count as we expect.
+  #
+  # @param reported_messages [Hash] JSON representing an Update Application
+  #   reports sent by the Contrast Service during this test run.
+  # @return [Boolean]
+  def match? reported_messages
+    reported_messages.any? do |message|
+      libraries = message.fetch('libraries', nil)
+      libraries&.any? { |library| library_match?(library) }
+    end
+  end
+
+  # A reported library matches this test if it has the same hash, gem, url
+  # version, and file count as we expect.
+  #
+  # @param reported_library [Hash] JSON representing an entity from the
+  #   `libraries` field of an Update Application report
+  # @return [Boolean]
+  def library_match? reported_library
+    reported_library['hash'] == @hash &&
+        reported_library['file'] == @gem &&
+        reported_library['version'] == @version &&
+        reported_library['classCount'] == @file_count &&
+        reported_library['url'] == @url
+  end
+end

--- a/spec/integration/messages/library_discovery/rails_test.json
+++ b/spec/integration/messages/library_discovery/rails_test.json
@@ -1,0 +1,30 @@
+[
+  {
+    "hash": "54dc19bef898b700b6f51ac1a025b0d310708a5e1c1b127ec35ed4dafb11619d",
+    "file": "parallel",
+    "version": "1.19.2",
+    "classCount": 3,
+    "url": "https://github.com/grosser/parallel"
+  },
+  {
+    "hash": "741448db59366073e86fc965ba403f881c636b79a2c39a48d0486f2607182e94",
+    "file": "rails-controller-testing",
+    "version": "1.0.5",
+    "classCount": 7,
+    "url": "https://github.com/rails/rails-controller-testing"
+  },
+  {
+    "hash": "ca788a49ac8312241c2ca97e261e4d82c930512a82fb67648142e0ec884e6b83",
+    "file": "actionmailbox",
+    "version": "6.0.3.4",
+    "classCount": 21,
+    "url": "https://rubyonrails.org"
+  },
+  {
+    "hash": "9b401338e287c50cd2354353b4b781d3766d863cae413b2a1bf585d237131e9c",
+    "file": "minitest",
+    "version": "5.14.2",
+    "classCount": 14,
+    "url": "https://github.com/seattlerb/minitest"
+  }
+]

--- a/spec/integration/messages/library_discovery/sinatra_test.json
+++ b/spec/integration/messages/library_discovery/sinatra_test.json
@@ -1,0 +1,9 @@
+[
+  {
+    "hash": "f323e4446f3e2a132dcaaa134f89caddb29dd88370317f4f32faf5797f1ea535",
+    "file": "sinatra",
+    "version": "2.1.0",
+    "classCount": 6,
+    "url": "http://sinatrarb.com/"
+  }
+]

--- a/spec/integration/messages/library_usage/library_usage_test_case.rb
+++ b/spec/integration/messages/library_usage/library_usage_test_case.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require_relative '../test_case'
+
+# This tests covers the runtime discovery of Library Usage in the Inventory
+# feature set of the Contrast Agent.
+class LibraryUsageTestCase < TestCase
+  def self.msg_source
+    'activity_application'
+  end
+
+  def initialize data
+    super
+    @hash = data['hash']
+    @files = data['files']
+  end
+
+  def name
+    @hash
+  end
+
+  # Determines if at least one message from our msg_source matches this
+  # testcase.
+  #
+  # @param reported_messages [Array<Hash>] an array of JSON representing the
+  #   Activity Application reports sent by the Contrast Service during this
+  #   test run.
+  def assert! reported_messages
+    @found = match?(reported_messages)
+  end
+
+  private
+
+  # A reported message matches this test if it has the same hash and all of the
+  # expected classes. It may have more classes than we expect, but it must at
+  # least have those
+  #
+  # @param reported_messages [Hash] JSON representing an Activity Application
+  #   reports sent by the Contrast Service during this test run.
+  # @return [Boolean]
+  def match? reported_messages
+    reported_messages.any? do |message|
+      libraries = message.fetch('inventory', nil)&.fetch('libraries', nil)
+      libraries&.any? { |library| library_match?(library) }
+    end
+  end
+
+  # A reported library matches this test if it has the same hash and all of the
+  # expected classes. It may have more classes than we expect, but it must at
+  # least have those
+  #
+  # @param reported_library [Hash] JSON representing an entity from the
+  #   `inventory.libraries` field of an Activity Application report
+  # @return [Boolean]
+  def library_match? reported_library
+    return false unless reported_library['sha1'] == @hash
+    return true if @files.empty?
+
+    reported_files = reported_library['classes']
+    @files.all? { |expected| reported_files.include?(expected) }
+  end
+end

--- a/spec/integration/messages/library_usage/rails_test.json
+++ b/spec/integration/messages/library_usage/rails_test.json
@@ -1,0 +1,39 @@
+[
+  {
+    "hash": "54dc19bef898b700b6f51ac1a025b0d310708a5e1c1b127ec35ed4dafb11619d",
+    "files": [
+      "/lib/parallel/version.rb",
+      "/lib/parallel/processor_count.rb",
+      "/lib/parallel.rb"
+    ]
+  },
+  {
+    "hash": "741448db59366073e86fc965ba403f881c636b79a2c39a48d0486f2607182e94",
+    "files": [
+      "/lib/rails/controller/testing/test_process.rb",
+      "/lib/rails/controller/testing/integration.rb",
+      "/lib/rails/controller/testing/template_assertions.rb",
+      "/lib/rails/controller/testing.rb",
+      "/lib/rails/controller/testing/railtie.rb",
+      "/lib/rails/controller/testing/version.rb",
+      "/lib/rails-controller-testing.rb"
+    ]
+  },
+  {
+    "hash": "ca788a49ac8312241c2ca97e261e4d82c930512a82fb67648142e0ec884e6b83",
+    "files": [
+      "/lib/action_mailbox/mail_ext/from_source.rb",
+      "/lib/action_mailbox/mail_ext/address_equality.rb",
+      "/lib/action_mailbox/mail_ext/recipients.rb",
+      "/lib/action_mailbox/mail_ext/addresses.rb",
+      "/lib/action_mailbox/mail_ext.rb",
+      "/lib/action_mailbox.rb",
+      "/lib/action_mailbox/engine.rb",
+      "/lib/action_mailbox/mail_ext/address_wrapping.rb"
+    ]
+  },
+  {
+    "hash": "9b401338e287c50cd2354353b4b781d3766d863cae413b2a1bf585d237131e9c",
+    "files": []
+  }
+]

--- a/spec/integration/messages/library_usage/sinatra_test.json
+++ b/spec/integration/messages/library_usage/sinatra_test.json
@@ -1,0 +1,13 @@
+[
+  {
+    "hash": "f323e4446f3e2a132dcaaa134f89caddb29dd88370317f4f32faf5797f1ea535",
+    "files": [
+      "/lib/sinatra/version.rb",
+      "/lib/sinatra/base.rb",
+      "/lib/sinatra/main.rb",
+      "/lib/sinatra.rb",
+      "/lib/sinatra/indifferent_hash.rb",
+      "/lib/sinatra/show_exceptions.rb"
+    ]
+  }
+]

--- a/spec/integration/messages/route/route_test_case.rb
+++ b/spec/integration/messages/route/route_test_case.rb
@@ -1,43 +1,35 @@
 # frozen_string_literal: true
 
-class RouteTestCase
+require_relative '../test_case'
+
+# This tests covers the runtime discovery of Observed Routes in the Assess
+# feature set of the Contrast Agent.
+class RouteTestCase < TestCase
   def self.msg_source
     'routes_observed'
   end
 
   def initialize data
+    super
     @signature = data['signature']
     @verb = data['verb']
     @url = data['url']
     @sources = data['sources']
-    @found = false
   end
 
-  def found?
-    !!@found
-  end
-
-  def has_ticket?
-    !!@ticket
-  end
-
-  def passed?
-    found? || has_ticket?
-  end
-
-  def to_s
-    "#{ @signature } - #{ found? } #{ " - Ticket: #{ @ticket }" if has_ticket? }"
+  def name
+    @signature
   end
 
   def assert! route_observed_messages
     @found = match?(route_observed_messages)
   end
 
+  private
+
   def match? route_observed_messages
     route_observed_messages.any? { |m| message_match?(m) }
   end
-
-  private
 
   # A message matches if it has the same signature, verb, and url and all of
   # the sources that we're checking for.

--- a/spec/integration/messages/test_case.rb
+++ b/spec/integration/messages/test_case.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+# This class is the base for all of our tests. It'll be used to assert that a
+# message was sent from the Contrast Service to the Contrast UI for a given
+# feature of the Contrast Agent.
+#
+# A passing test means that a message of the given type matched the given
+# criteria, which means it has at least the data expected in the format given.
+# It does not mean that the message does not have other data or purposes.
+class TestCase
+
+  # A msg_source is the file extension that should be checked by this test. For
+  # instance, if the message looks like `20201104-140910.621-foo.json`, then
+  # the source here should be `foo`.
+  #
+  # @return [String] the name of the JSON file to match on for this test
+  def self.msg_source
+    raise NoMethodError, 'This method should be overridden with the message type to which this test pertains.'
+  end
+
+  # Determines if at least one message from our msg_source matches this
+  # testcase.
+  #
+  # @param _reported_messages [Array<Hash>] an array of JSON representing the
+  #   messages of the .msg_source type that were sent to the Contrast UI during
+  #   the application execution
+  def assert! _reported_messages
+    raise NoMethodError, 'This method should be overridden with the assertion needed to compare the TestCase to the messages.'
+  end
+
+  # Some name used in the #to_s of this test to tell it from others of its type
+  #
+  # @return [String]
+  def name
+    raise NoMethodError, 'This method should be overridden with the unique identifier for this test.'
+  end
+
+  def initialize data
+    @found = false
+    @ticket = data['ticket']
+  end
+
+  # Has a message that matches this test case been reported?
+  #
+  # @return [Boolean]
+  def found?
+    @found
+  end
+
+  # Is there a ticket associated with this test, meaning it is expected to fail
+  # or its result is not to impact the testsuite?
+  #
+  # @return [Boolean]
+  def ticketed?
+    !@ticket.nil?
+  end
+
+  # A test passes if it's been found or if its results should not be counted
+  # against the suite.
+  #
+  # @return [Boolean]
+  def passed?
+    found? || ticketed?
+  end
+
+  def to_s
+    "#{ name } - #{ found? } #{ " - Ticket: #{ @ticket }" if ticketed? }"
+  end
+
+end

--- a/spec/integration/messages/vulnerability/vulnerability_test_case.rb
+++ b/spec/integration/messages/vulnerability/vulnerability_test_case.rb
@@ -1,51 +1,58 @@
 # frozen_string_literal: true
 
-class VulnerabilityTestCase
+require_relative '../test_case'
+
+# This test covers the runtime discovery of Vulnerabilities in the Assess
+# feature set of the Contrast Agent.
+class VulnerabilityTestCase < TestCase
   def self.msg_source
     'traces'
   end
 
   def initialize data
+    super
     @rule_id = data['rule_id']
     @dataflow = data['dataflow']
     @trigger_class = data['trigger_class']
     @trigger_method = data['trigger_method']
-    @ticket = data['ticket']
-    @found = false
   end
 
+  def name
+    @rule_id
+  end
+
+  # Determines if at least one message from our msg_source matches this
+  # testcase.
+  #
+  # @param reported_messages [Array<Hash>] an array of JSON representing the
+  #   Trace reports sent by the Contrast Service during this test run.
+  def assert! reported_messages
+    @found = reported_messages.any? { |vulnerability| vulnerability_match?(vulnerability) }
+  end
+
+  private
+
+  # A reported vulnerability matches this test if it is of the same rule type
+  # and is either not dataflow or is dataflow and has the expected events, as
+  # determined by their signature
+  #
+  # @param reported_vulnerability [Hash] JSON representing an entity from the
+  #   Traces report
+  # @return [Boolean]
+  def vulnerability_match? reported_vulnerability
+    return false unless reported_vulnerability['ruleId'] == @rule_id
+    return true unless dataflow?
+
+    reported_vulnerability['events'].any? do |action|
+      signature = action['signature']
+      signature['className'] == @trigger_class && signature['methodName'] == @trigger_method
+    end
+  end
+
+  # Is the vulnerability being tested for of a dataflow type?
+  #
+  # @return [Boolean]
   def dataflow?
     !!@dataflow
-  end
-
-  def found?
-    !!@found
-  end
-
-  def has_ticket?
-    !!@ticket
-  end
-
-  def passed?
-    found? || has_ticket?
-  end
-
-  def to_s
-    "#{ @rule_id } - #{ found? } #{ " - Ticket: #{ @ticket }" if has_ticket? }"
-  end
-
-  def assert! reported_messages
-    vulnerabilities = reported_messages.select { |m| m['ruleId'] == @rule_id }
-    # if this isn't a dataflow rule, then as long as an instance was reported
-    # it will pass
-    return @found = !vulnerabilities.empty? unless dataflow?
-
-    @found =
-      vulnerabilities.any? do |trace_message|
-        trace_message['events'].any? do |action|
-          signature = action['signature']
-          signature['className'] == @trigger_class && signature['methodName'] == @trigger_method
-        end
-      end
   end
 end


### PR DESCRIPTION
✅ add library testing as message type

I've added new tests for Discovered and Observed Libraries, which are reported in the update_application and activity_application messages respectively. These tests assert that for some of the known libraries in the application, a corresponding message is reported back to the Contrast UI.

In addition, I've updated the tests to derive from a common TestCase class and done away with the explicit `verify_feature` methods in favor of an extensible map and added comments to the tests to make clear what they're testing for.

To test this, please follow the instructions in the README to execute the test. A status code 0 and seeing mention of Verifying rails - route in the output shows this works.