### PR TITLE
RUBY-1035 Performance Testing

### DIFF
--- a/docker/Dockerfile_puma
+++ b/docker/Dockerfile_puma
@@ -7,6 +7,7 @@ WORKDIR app
 
 ENV SECRET_KEY_BASE=foobarblah
 ENV RAILS_SERVE_STATIC_FILES=true
+ENV WEB_CONCURRENCY=1
 ENV RAILS_ENV=production
 
 COPY agent/* agent/

--- a/docker/performance/Dockerfile_assess
+++ b/docker/performance/Dockerfile_assess
@@ -1,6 +1,12 @@
 FROM ruby:2.7
 ARG PORT_ARG=3009
 
+# Install the agent
+ENV CI_TEST=false
+# And force proper modes
+ENV CONTRAST__ASSESS__ENABLE=true
+ENV CONTRAST__PROTECT__ENABLE=false
+
 RUN apt-get update && apt-get install -y build-essential coreutils
 
 WORKDIR app

--- a/docker/performance/Dockerfile_no_agent
+++ b/docker/performance/Dockerfile_no_agent
@@ -1,6 +1,9 @@
 FROM ruby:2.7
 ARG PORT_ARG=3009
 
+# Don't install the agent
+ENV CI_TEST=false
+
 RUN apt-get update && apt-get install -y build-essential coreutils
 
 WORKDIR app
@@ -15,14 +18,9 @@ COPY Gemfile.lock .
 COPY vulneruby_engine.gemspec .
 COPY lib/vulneruby_engine/version.rb ./lib/vulneruby_engine/version.rb
 
-# Used in CI to install gem dropped in ./agent/ directory
-RUN gem install ./agent/contrast-agent.gem
-
 ENV PUMA=true
 RUN bundle config set with 'puma'
 RUN bundle install
-
-ENV CI_TEST=true
 
 COPY . .
 RUN rm **/*.log | true

--- a/docker/performance/Dockerfile_protect
+++ b/docker/performance/Dockerfile_protect
@@ -1,6 +1,12 @@
 FROM ruby:2.7
 ARG PORT_ARG=3009
 
+# Install the agent
+ENV CI_TEST=false
+# And force proper modes
+ENV CONTRAST__ASSESS__ENABLE=false
+ENV CONTRAST__PROTECT__ENABLE=true
+
 RUN apt-get update && apt-get install -y build-essential coreutils
 
 WORKDIR app

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -55,7 +55,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  config.log_level = :error
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]

--- a/spec/dummy/config/environments/production.rb
+++ b/spec/dummy/config/environments/production.rb
@@ -14,7 +14,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
 
   # Ensures that a master key has been made available in either
@@ -30,7 +30,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/spec/dummy/config/puma.rb
+++ b/spec/dummy/config/puma.rb
@@ -6,8 +6,8 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 5)
-min_threads_count = ENV.fetch('RAILS_MIN_THREADS', max_threads_count)
+max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 32)
+min_threads_count = ENV.fetch('RAILS_MIN_THREADS', 8)
 threads(min_threads_count, max_threads_count)
 
 # Specifies the `port` that Puma will listen on to receive requests;
@@ -28,7 +28,7 @@ pidfile(ENV.fetch('PIDFILE', 'tmp/pids/server.pid'))
 # Workers do not work on JRuby or Windows (both of which do not support
 # processes).
 #
-# workers ENV.fetch("WEB_CONCURRENCY") { 2 }
+workers ENV.fetch("WEB_CONCURRENCY") { 5 }
 
 # Use the `preload_app!` method when specifying a `workers` number.
 # This directive tells Puma to first boot the application and load code


### PR DESCRIPTION
:construction_worker: :white_check_mark: add perf testing images

Update the default configurations for the `puma` tests to run in production mode w/ settings that allow us to performance test the agent