### PR TITLE
RUBY-1068 Disable CSRF Protection

### DIFF
--- a/app/controllers/vulneruby_engine/application_controller.rb
+++ b/app/controllers/vulneruby_engine/application_controller.rb
@@ -5,6 +5,7 @@ module VulnerubyEngine
   # settings here to add new response vulnerabilities as we begin to test them.
   class ApplicationController < ActionController::Base
     protect_from_forgery with: :exception
+    skip_before_action :verify_authenticity_token
 
     def home
       render('layouts/vulneruby_engine/home')

--- a/docker/performance/Dockerfile_base
+++ b/docker/performance/Dockerfile_base
@@ -39,7 +39,9 @@ RUN bundle install
 RUN mkdir -p /tmp/agent/messages
 RUN mkdir -p tmp/pids
 ENV CONTRAST__AGENT__LOGGER__PATH=/tmp/agent/agent.log
+ENV CONTRAST__AGENT__LOGGER__LEVEL=INFO
 ENV CONTRAST__AGENT__SERVICE__LOGGER__PATH=/tmp/agent/service.log
+ENV CONTRAST__AGENT__SERVICE__LOGGER__LEVEL=INFO
 ENV CONTRAST__API__REQUEST_AUDIT__PATH=/tmp/agent/messages
 ENV APP_LOG=/tmp/agent/app.log
 


### PR DESCRIPTION
:bug: intentionally disable CSRF protection to allow testing... plus this is supposed to be vulnerable
:loud_sound: set logging to INFO per perf rules

With this, you should be able to run the following:

`echo "POST http://localhost:3009/vulneruby_engine/cmdi" | vegeta attack -body ./attack.json -duration=1s -rate=10 | vegeta report --type=text`

where `attack.json` is a file with the contents `command=ls`

and see the output have a `Success [ratio]` of `100%`