### PR TITLE
Fixup gem path and clenaup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 source('https://rubygems.org')
+
+
 git_source(:github) { |repo| "https://github.com/#{ repo }.git" }
 
 # Declare your gem's dependencies in vulneruby_engine.gemspec.
@@ -41,4 +43,8 @@ end
 
 # To use a debugger
 # gem 'byebug', group: [:development, :test]gem 'contrast-agent', path: './agent'
-gem 'contrast-agent' if !!ENV['CI_TEST']
+if (agent=`gem which contrast-agent`.gsub('/lib/contrast-agent.rb', ''))
+  gem 'contrast-agent', path: agent_path if !!ENV['CI_TEST']
+else
+   gem 'contrast-agent' if !!ENV['CI_TEST']
+end

--- a/Gemfile
+++ b/Gemfile
@@ -41,6 +41,8 @@ end
 
 # To use a debugger
 # gem 'byebug', group: [:development, :test]gem 'contrast-agent', path: './agent'
+#
+# agent_path here is used to tell bundler to use a local gem path pointed to by gem which contrast-agent.
 if (agent_path=ENV['AGENT_PATH'])
   agent_path = agent_path.gsub('/lib/contrast-agent.rb', '')
   gem 'contrast-agent', path: agent_path if !!ENV['CI_TEST']

--- a/Gemfile
+++ b/Gemfile
@@ -43,7 +43,8 @@ end
 
 # To use a debugger
 # gem 'byebug', group: [:development, :test]gem 'contrast-agent', path: './agent'
-if (agent=`gem which contrast-agent`.gsub('/lib/contrast-agent.rb', ''))
+if (agent_path=`gem which contrast-agent`.gsub('/lib/contrast-agent.rb', ''))
+  puts agent_path
   gem 'contrast-agent', path: agent_path if !!ENV['CI_TEST']
 else
    gem 'contrast-agent' if !!ENV['CI_TEST']

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 source('https://rubygems.org')
-
-
 git_source(:github) { |repo| "https://github.com/#{ repo }.git" }
 
 # Declare your gem's dependencies in vulneruby_engine.gemspec.

--- a/Gemfile
+++ b/Gemfile
@@ -43,9 +43,11 @@ end
 
 # To use a debugger
 # gem 'byebug', group: [:development, :test]gem 'contrast-agent', path: './agent'
-if (agent_path=`gem which contrast-agent`.gsub('/lib/contrast-agent.rb', ''))
-  puts agent_path
+if (agent_path=ENV['AGENT_PATH'])
+  agent_path = agent_path.gsub('/lib/contrast-agent.rb', '')
   gem 'contrast-agent', path: agent_path if !!ENV['CI_TEST']
 else
    gem 'contrast-agent' if !!ENV['CI_TEST']
 end
+
+gem "sqlite", "~> 1.0"

--- a/Gemfile
+++ b/Gemfile
@@ -47,5 +47,3 @@ if (agent_path=ENV['AGENT_PATH'])
 else
    gem 'contrast-agent' if !!ENV['CI_TEST']
 end
-
-gem "sqlite", "~> 1.0"

--- a/build_bases.sh
+++ b/build_bases.sh
@@ -6,7 +6,7 @@ SCRIPTNAME=$(basename "${BASH_SOURCE[0]}")
 APP_ROOT=$(dirname "${BASH_SOURCE[0]}")
 GIT_REPO=contrast-security-oss/vulneruby_engine
 
-RUBY_VERS="2.5 2.6 2.7 3.0"
+RUBY_VERS="2.5 2.6 2.7 3"
 
 
 usage() {
@@ -15,7 +15,11 @@ Usa ge: $SCRIPTNAME [-h] [options]
 
     Build and upload base images for supported Ruby versions: $RUBY_VERS
 
-    Sign in to these first.
+    Sign into GitHub with a PAT before running this.
+
+    To do this in pipeline, research:
+        https://docs.github.com/en/packages/guides/pushing-and-pulling-docker-images
+        'you can use the GITHUB_TOKEN to publish and install packages'
 
 Available options:
 

--- a/docker/Dockerfile_unicorn4
+++ b/docker/Dockerfile_unicorn4
@@ -6,6 +6,7 @@ ENV PORT=$PORT_ARG
 
 # Because we also test Unicorn 5, we have to turn that off and re-install to get Unicorn 4
 ENV UNICORN_4=true
+COPY Gemfile ./Gemfile
 RUN bundle config set with 'unicorn_4'
 RUN bundle install
 

--- a/docker/Dockerfile_unicorn4
+++ b/docker/Dockerfile_unicorn4
@@ -6,8 +6,8 @@ ENV PORT=$PORT_ARG
 
 # Because we also test Unicorn 5, we have to turn that off and re-install to get Unicorn 4
 ENV UNICORN_4=true
-RUN bundle config set with 'unicorn_4'
-RUN bundle install
+RUN unset CI_TEST && bundle config set with 'unicorn_4'
+RUN unset CI_TEST && bundle install
 
 # Enable the web server gem
 ENV UNICORN_4_TEST=true

--- a/docker/Dockerfile_unicorn4
+++ b/docker/Dockerfile_unicorn4
@@ -6,9 +6,10 @@ ENV PORT=$PORT_ARG
 
 # Because we also test Unicorn 5, we have to turn that off and re-install to get Unicorn 4
 ENV UNICORN_4=true
-COPY Gemfile ./Gemfile
 RUN bundle config set with 'unicorn_4'
-RUN bundle install
+
+RUN AGENT_PATH=`gem which contrast-agent` bundle install
+
 
 # Enable the web server gem
 ENV UNICORN_4_TEST=true

--- a/docker/Dockerfile_unicorn4
+++ b/docker/Dockerfile_unicorn4
@@ -6,8 +6,8 @@ ENV PORT=$PORT_ARG
 
 # Because we also test Unicorn 5, we have to turn that off and re-install to get Unicorn 4
 ENV UNICORN_4=true
-RUN unset CI_TEST && bundle config set with 'unicorn_4'
-RUN unset CI_TEST && bundle install
+RUN bundle config set with 'unicorn_4'
+RUN bundle install
 
 # Enable the web server gem
 ENV UNICORN_4_TEST=true

--- a/docker/Dockerfile_unicorn5
+++ b/docker/Dockerfile_unicorn5
@@ -6,15 +6,12 @@ ENV PORT=$PORT_ARG
 
 # Because we also test Unicorn 4, we have to turn that off and re-install to get Unicorn 5
 ENV UNICORN_5=true
-COPY Gemfile ./Gemfile
-RUN cat Gemfile
 RUN bundle config set with 'unicorn_5'
-RUN bundle install
+
+RUN AGENT_PATH=`gem which contrast-agent` bundle install
 
 # Enable the web server gem
 ENV UNICORN_5_TEST=true
-
-
 
 # Name and run the application
 RUN ./docker/app_name_generator.sh Unicorn5 >> /tmp/app_name.txt

--- a/docker/Dockerfile_unicorn5
+++ b/docker/Dockerfile_unicorn5
@@ -7,7 +7,7 @@ ENV PORT=$PORT_ARG
 # Because we also test Unicorn 4, we have to turn that off and re-install to get Unicorn 5
 ENV UNICORN_5=true
 RUN bundle config set with 'unicorn_5'
-RUN bundle add unicorn
+RUN unset CI_TEST && bundle add unicorn
 
 # Enable the web server gem
 ENV UNICORN_5_TEST=true

--- a/docker/Dockerfile_unicorn5
+++ b/docker/Dockerfile_unicorn5
@@ -6,6 +6,7 @@ ENV PORT=$PORT_ARG
 
 # Because we also test Unicorn 4, we have to turn that off and re-install to get Unicorn 5
 ENV UNICORN_5=true
+COPY Gemfile ./Gemfile
 RUN cat Gemfile
 RUN bundle config set with 'unicorn_5'
 RUN bundle install

--- a/docker/Dockerfile_unicorn5
+++ b/docker/Dockerfile_unicorn5
@@ -6,6 +6,7 @@ ENV PORT=$PORT_ARG
 
 # Because we also test Unicorn 4, we have to turn that off and re-install to get Unicorn 5
 ENV UNICORN_5=true
+RUN cat Gemfile
 RUN bundle config set with 'unicorn_5'
 RUN bundle install
 

--- a/docker/Dockerfile_unicorn5
+++ b/docker/Dockerfile_unicorn5
@@ -6,7 +6,7 @@ ENV PORT=$PORT_ARG
 
 # Because we also test Unicorn 4, we have to turn that off and re-install to get Unicorn 5
 ENV UNICORN_5=true
-RUN bundle config set with 'unicorn_5'
+RUN unset CI_TEST bundle config set with 'unicorn_5'
 RUN unset CI_TEST && bundle add unicorn
 
 # Enable the web server gem

--- a/docker/Dockerfile_unicorn5
+++ b/docker/Dockerfile_unicorn5
@@ -6,11 +6,12 @@ ENV PORT=$PORT_ARG
 
 # Because we also test Unicorn 4, we have to turn that off and re-install to get Unicorn 5
 ENV UNICORN_5=true
-RUN unset CI_TEST bundle config set with 'unicorn_5'
-RUN unset CI_TEST && bundle add unicorn
+RUN bundle config set with 'unicorn_5'
+RUN bundle install
 
 # Enable the web server gem
 ENV UNICORN_5_TEST=true
+
 
 
 # Name and run the application

--- a/docker/Dockerfile_unicorn5
+++ b/docker/Dockerfile_unicorn5
@@ -7,9 +7,7 @@ ENV PORT=$PORT_ARG
 # Because we also test Unicorn 4, we have to turn that off and re-install to get Unicorn 5
 ENV UNICORN_5=true
 RUN bundle config set with 'unicorn_5'
-RUN bundle install
-
-RUN gem install ./agent/contrast-agent.gem
+RUN bundle add unicorn
 
 # Enable the web server gem
 ENV UNICORN_5_TEST=true

--- a/docker/Dockerfile_unicorn5
+++ b/docker/Dockerfile_unicorn5
@@ -9,9 +9,10 @@ ENV UNICORN_5=true
 RUN bundle config set with 'unicorn_5'
 RUN bundle install
 
+RUN gem install ./agent/contrast-agent.gem
+
 # Enable the web server gem
 ENV UNICORN_5_TEST=true
-
 
 
 # Name and run the application

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -13,6 +13,10 @@ Bundler.require(:unicorn_5) if !!ENV['UNICORN_5_TEST']
 
 require('vulneruby_engine')
 
+require('warning')
+Warning.ignore(/Using the last argument as keyword parameters is deprecated/)
+
+
 module Dummy
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/vulneruby_engine.gemspec
+++ b/vulneruby_engine.gemspec
@@ -14,6 +14,7 @@ def self.add_dev_dependencies spec
   spec.add_development_dependency 'rspec_junit_formatter', '0.3.0'
   spec.add_development_dependency('simplecov', '~> 0.18.5')
   spec.add_development_dependency('sqlite3')
+  spec.add_development_dependency('warning')
   spec.add_development_dependency('watir')
   spec.add_development_dependency('webdrivers', '~> 4.0')
 end


### PR DESCRIPTION
Point bundler to global gem path for `contrast-agent.gem` in unicorn 4 and 5 docker images.

Some other cleanup as well.

See confluence wiki here: https://contrast.atlassian.net/wiki/spaces/RUBY/pages/1887209047/Bundle+--+Use+Local+.gem+file

See pipeline run here: https://github.com/Contrast-Security-Inc/ruby-agent/runs/1843240223?check_suite_focus=true#step:10:194
The pipeline did fail, but not due to this issue which is resolved.
See 
```
Using contrast-agent 4.3.0 from source at /usr/local/bundle/gems/contrast-agent-4.3.0
```
Passing Run Here: https://github.com/Contrast-Security-Inc/ruby-agent/actions/runs/548439281

Also add warning filter for KWargs.