### PR TITLE
Ruby 1093 version tests

### DIFF
--- a/docker/Dockerfile_passenger
+++ b/docker/Dockerfile_passenger
@@ -9,4 +9,4 @@ ENV PASSENGER_TEST=true
 
 # Name and run the application
 RUN ./docker/app_name_generator.sh Passenger >> /tmp/app_name.txt
-CMD CONTRAST_CONFIG_PATH=/app/contrast_security.yaml CONTRAST__APPLICATION__NAME=$(cat /tmp/app_name.txt) bundle exec rails s -p $PORT
+CMD CONTRAST_CONFIG_PATH=/app/contrast_security.yaml CONTRAST__APPLICATION__NAME=$(cat /tmp/app_name.txt) PASSENGER_START_TIMEOUT=300 bundle exec rails s -p $PORT

--- a/spec/dummy/config/puma.rb
+++ b/spec/dummy/config/puma.rb
@@ -8,7 +8,7 @@
 #
 max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 32)
 min_threads_count = ENV.fetch('RAILS_MIN_THREADS', 8)
-worker_timeout = 300
+worker_timeout 300
 threads(min_threads_count, max_threads_count)
 
 # Specifies the `port` that Puma will listen on to receive requests;

--- a/spec/dummy/config/puma.rb
+++ b/spec/dummy/config/puma.rb
@@ -8,6 +8,7 @@
 #
 max_threads_count = ENV.fetch('RAILS_MAX_THREADS', 32)
 min_threads_count = ENV.fetch('RAILS_MIN_THREADS', 8)
+worker_timeout = 300
 threads(min_threads_count, max_threads_count)
 
 # Specifies the `port` that Puma will listen on to receive requests;


### PR DESCRIPTION
This'll allow for startup with the 2.5 Ruby Tests, which [require significant more time](https://contrast.atlassian.net/wiki/spaces/RUBY/pages/790004285/Known+Issues#Interpolation-in-2.5) as they have to rewrite and replace any file using String interpolation.

For passenger, without these changes, the app starts, but it's tight. This gives us some wiggle room. 

For Puma, without these changes, locally I get:
> [19603] Puma starting in cluster mode...
[19603] * Version 3.12.6 (ruby 2.5.8-p224), codename: Llamas in Pajamas
[19603] * Min threads: 8, max threads: 32
[19603] * Environment: production
[19603] * Process workers: 5
[19603] * Phased restart available
[19603] * Listening on tcp://0.0.0.0:3009
[19603] Use Ctrl-C to stop
[Contrast Security] [DEPRECATION] Support for Ruby 2.5 will be removed in April 2021. Please contact Customer Support prior if you require continued support.
[Contrast Security] [DEPRECATION] Support for Ruby 2.5 will be removed in April 2021. Please contact Customer Support prior if you require continued support.
[Contrast Security] [DEPRECATION] Support for Ruby 2.5 will be removed in April 2021. Please contact Customer Support prior if you require continued support.
[Contrast Security] [DEPRECATION] Support for Ruby 2.5 will be removed in April 2021. Please contact Customer Support prior if you require continued support.
[Contrast Security] [DEPRECATION] Support for Ruby 2.5 will be removed in April 2021. Please contact Customer Support prior if you require continued support.
[19603] ! Terminating timed out worker: 19607
[19603] ! Terminating timed out worker: 19608
[19603] ! Terminating timed out worker: 19610
[19603] ! Terminating timed out worker: 19611
[19603] ! Terminating timed out worker: 19612
[Contrast Security] [DEPRECATION] Support for Ruby 2.5 will be removed in April 2021. Please contact Customer Support prior if you require continued support.
[Contrast Security] [DEPRECATION] Support for Ruby 2.5 will be removed in April 2021. Please contact Customer Support prior if you require continued support.
[Contrast Security] [DEPRECATION] Support for Ruby 2.5 will be removed in April 2021. Please contact Customer Support prior if you require continued support.
[Contrast Security] [DEPRECATION] Support for Ruby 2.5 will be removed in April 2021. Please contact Customer Support prior if you require continued support.
[Contrast Security] [DEPRECATION] Support for Ruby 2.5 will be removed in April 2021. Please contact Customer Support prior if you require continued support.
...
With them, I get the app to response. 

