### PR TITLE
RUBY-1155 Added Grape controller, spec and routes

### DIFF
--- a/app/controllers/vulneruby_engine/grape_controller.rb
+++ b/app/controllers/vulneruby_engine/grape_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'grape'
+
+module VulnerubyEngine
+  # Base controller for the Grape framework mount
+  class GrapeController < Grape::API
+    format :json
+  
+    get :reflected_xss do
+      { :attack => 'Reflected XSS'}
+    end
+
+    post :reflected_xss do
+      @result = params[:data]
+      { result: @result }
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,4 +26,6 @@ VulnerubyEngine::Engine.routes.draw do
 
   get  '/sinatra' => VulnerubyEngine::SinatraController, :anchor => false # rubocop:disable Style/StringHashKeys
   post '/sinatra' => VulnerubyEngine::SinatraController, :anchor => false # rubocop:disable Style/StringHashKeys
+  get  '/grape' => VulnerubyEngine::GrapeController, :anchor => false # rubocop:disable Style/StringHashKeys
+  post '/grape' => VulnerubyEngine::GrapeController, :anchor => false # rubocop:disable Style/StringHashKeys
 end

--- a/spec/app/controllers/grape/reflected_xss_spec.rb
+++ b/spec/app/controllers/grape/reflected_xss_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+RSpec.describe('Reflected XSS Controller', type: :request) do
+  let(:route) { '/vulneruby_engine/grape/reflected_xss' }
+
+  describe 'GET /grape/reflected_xss' do
+    it 'gets the response body' do
+      get route
+      expect(response.body).to(include('Reflected XSS'))
+    end
+  end
+
+  describe 'POST /grape/reflected_xss' do
+    it 'renders POST response params' do
+      post route,
+           params: { data: '<script>alert(1);</script>' }
+      expect(JSON.parse(response.body).symbolize_keys).to(include( result: '<script>alert(1);</script>'))
+    end
+  end
+end

--- a/vulneruby_engine.gemspec
+++ b/vulneruby_engine.gemspec
@@ -33,6 +33,7 @@ def self.add_dependencies spec
   spec.add_dependency('rails', '~> 6.0.3', '>= 6.0.3.1')
   spec.add_dependency('rake', '~> 12.0')
   spec.add_dependency('sinatra', '~> 2.0')
+  spec.add_dependency('grape', '~> 1.5.3')
 end
 
 # Describe your gem and declare its dependencies:


### PR DESCRIPTION
### Changes Introduced  :sparkles: 
This PR adds support for Grape framework including controller, routes and specs

### How To Test :alembic:
Review code
run `bundle exec rspec`

### Additional Details :speech_balloon:
[RUBY-1155 Grape: Add App Test](https://contrast.atlassian.net/browse/RUBY-1155)