### PR TITLE
Added the missing tests

### DIFF
--- a/app/controllers/vulneruby_engine/grape_controller.rb
+++ b/app/controllers/vulneruby_engine/grape_controller.rb
@@ -6,14 +6,83 @@ module VulnerubyEngine
   # Base controller for the Grape framework mount
   class GrapeController < Grape::API
     format :json
-  
-    get :reflected_xss do
-      { :attack => 'Reflected XSS'}
+
+    get '/' do
+      'Hello Grape!'
     end
 
-    post :reflected_xss do
-      @result = params[:data]
+    get '/reflected_xss' do
+      { attack: 'Reflected XSS' }
+    end
+
+    post '/reflected_xss' do
+      @result = params[:data].html_safe
       { result: @result }
+    end
+
+    post '/unvalidated_redirect' do
+      redirect params[:url]
+    end
+
+    post '/ssrf' do
+      uri = CGI.unescape(params[:uri].split('=').last)
+      Net::HTTP.get(URI(uri))
+    end
+
+    get '/unset_rack_session' do
+      Rack::Session::Cookie.new(
+          {},
+          {
+              key: 'rack.session',
+              httponly: true,
+              secret: 'very_secret_secret',
+              old_secret: 'some_old_secret',
+              secure: true
+          })
+      'Expire time is unset'
+    end
+
+    get '/secure_flag' do
+      Rack::Session::Cookie.new(
+          {},
+          {
+              key: 'rack.session',
+              httponly: true,
+              expire_after: 100,
+              secret: 'secret_new',
+              old_secret: 'old_secret'
+          })
+      'secure-flag'
+    end
+
+    get '/httponly_flag' do
+      Rack::Session::Cookie.new(
+          {},
+          {
+              key: 'rack.session',
+              httponly: false,
+              expire_after: 100,
+              secret: 'secret_new',
+              old_secret: 'old_secret',
+              secure: true
+          })
+      'httponly-flag'
+    end
+
+    post '/cmdi' do
+      Kernel.`(params['cmd'])
+    end
+
+    use Rack::Session::Cookie,
+        key: 'rack.session',
+        domain: 'foo.com',
+        path: '/',
+        expire_after: 2_592_000,
+        secret: 'change_me'
+
+    post '/trust_boundary' do
+      env['rack.session'][:HTTP_USER_AGENT] = params[:HTTP_USER_AGENT]
+      env['rack.session']
     end
   end
 end

--- a/spec/app/controllers/grape/cmdi_spec.rb
+++ b/spec/app/controllers/grape/cmdi_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe('Grape cmdi', type: :request) do
+  let(:route) { '/vulneruby_engine/grape/cmdi?cmd=ls' }
+
+  describe 'GET /grape/cdmi' do
+    it 'gets the response body' do
+      post route
+      expect(response.body).to(include('Rakefile'))
+    end
+  end
+end

--- a/spec/app/controllers/grape/httponly_flag_spec.rb
+++ b/spec/app/controllers/grape/httponly_flag_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe('Grape httponly flag missing', type: :request) do
+  let(:route) { '/vulneruby_engine/grape/httponly_flag' }
+
+  describe 'GET /grape/httponly_flag' do
+    it 'renders response' do
+      get route
+      expect(response.body).to(include('httponly-flag'))
+    end
+  end
+end

--- a/spec/app/controllers/grape/reflected_xss_spec.rb
+++ b/spec/app/controllers/grape/reflected_xss_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe('Reflected XSS Controller', type: :request) do
+RSpec.describe('Grape Reflected XSS', type: :request) do
   let(:route) { '/vulneruby_engine/grape/reflected_xss' }
 
   describe 'GET /grape/reflected_xss' do

--- a/spec/app/controllers/grape/secure_flag_spec.rb
+++ b/spec/app/controllers/grape/secure_flag_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe('Grape secure flag missing', type: :request) do
+  let(:route) { '/vulneruby_engine/grape/secure_flag' }
+
+  describe 'GET /grape/secure_flag' do
+    it 'renders response' do
+      get route
+      expect(response.body).to(include('secure-flag'))
+    end
+  end
+end

--- a/spec/app/controllers/grape/ssrf_spec.rb
+++ b/spec/app/controllers/grape/ssrf_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe('Grape ssrf', type: :request) do
+  let(:route) { '/vulneruby_engine/grape/ssrf?uri=https://www.example.com' }
+
+  describe 'POST /grape/ssrf' do
+    it 'get the uri' do
+      post(route)
+      expect(JSON.parse(response.body)).to(include('<h1>Example Domain</h1>'))
+    end
+  end
+end

--- a/spec/app/controllers/grape/trust_boundary_spec.rb
+++ b/spec/app/controllers/grape/trust_boundary_spec.rb
@@ -3,9 +3,9 @@
 RSpec.describe('Grape trust_boundary', type: :request) do
   let(:route) { '/vulneruby_engine/grape/trust_boundary' }
 
-  describe 'GET /grape/trust_boundary' do
+  describe 'POST /grape/trust_boundary' do
     it 'renders session_id' do
-      get(route, params: { 'HTTP_USER_AGENT' => 'test user agent' })
+      post(route, params: { 'HTTP_USER_AGENT' => 'test user agent' })
       expect(response.body).to(include('session_id'))
     end
   end

--- a/spec/app/controllers/grape/trust_boundary_spec.rb
+++ b/spec/app/controllers/grape/trust_boundary_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe('Grape trust_boundary', type: :request) do
+  let(:route) { '/vulneruby_engine/grape/trust_boundary' }
+
+  describe 'GET /grape/trust_boundary' do
+    it 'renders session_id' do
+      get(route, params: { 'HTTP_USER_AGENT' => 'test user agent' })
+      expect(response.body).to(include('session_id'))
+    end
+  end
+end

--- a/spec/app/controllers/grape/unset_rack_session_spec.rb
+++ b/spec/app/controllers/grape/unset_rack_session_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe('Grape unset rack session', type: :request) do
+  let(:route) { '/vulneruby_engine/grape/unset_rack_session' }
+
+  describe 'GET /grape/unset_rack_session' do
+    it 'renders response' do
+      get route
+      expect(response.body).to(include('Expire time is unset'))
+    end
+  end
+end

--- a/spec/app/controllers/grape/unvalidated_redirect_spec.rb
+++ b/spec/app/controllers/grape/unvalidated_redirect_spec.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+RSpec.describe('Grape unvalidated_redirect', type: :request) do
+  let(:route) { '/vulneruby_engine/grape/unvalidated_redirect' }
+
+  describe 'GET /grape/unvalidated_redirect' do
+    it 'redirects' do
+      post route, params: { url: 'https://www.example.com' }
+      expect(response.status).to(eq(302))
+    end
+  end
+end

--- a/spec/dummy/config.ru
+++ b/spec/dummy/config.ru
@@ -4,4 +4,5 @@
 
 require_relative('config/environment')
 
+use Rack::Session::Cookie
 run(Rails.application)


### PR DESCRIPTION
This PR adds the missing vulnerabilities tests

Should be merged after [Grape Integration for ruby-app-test](https://github.com/Contrast-Security-Inc/ruby-app-test/pull/18)

pending tests: Grape unvalidated_redirect, routes

_note_: `Grape` routes are not being observed by UI. The agent is not enabling support for `Grape`, only `Rails`.