### PR TITLE
Update nokogiri to a version that supports Ruby 3.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -150,7 +150,7 @@ GEM
     marcel (1.0.2)
     method_source (1.0.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.6.1)
+    mini_portile2 (2.7.1)
     minitest (5.15.0)
     mustermann (1.1.1)
       ruby2_keywords (~> 0.0.1)
@@ -172,8 +172,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.12.5)
-      mini_portile2 (~> 2.6.1)
+    nokogiri (1.13.1)
+      mini_portile2 (~> 2.7.0)
       racc (~> 1.4)
     numerizer (0.1.1)
     parallel (1.21.0)

--- a/build_bases.sh
+++ b/build_bases.sh
@@ -6,7 +6,7 @@ SCRIPTNAME=$(basename "${BASH_SOURCE[0]}")
 APP_ROOT=$(dirname "${BASH_SOURCE[0]}")
 GIT_REPO=contrast-security-oss/vulneruby_engine
 
-RUBY_VERS="2.6 2.7 3 3.1"
+RUBY_VERS="2.7 3 3.1"
 
 
 usage() {


### PR DESCRIPTION
Some updates to allow the images to actually be build.

Update nokogiri to a version that actually supports Ruby 3.1.

Also updated `build_bases.sh` to exclude ruby 2.6, as Rails 7 requires 2.7+. The existing 2.6 image will still be around for using with the agent until we remove support for it.