### PR TITLE
RUBY-1783-Scope-Performance

### DIFF
--- a/docker/Dockerfile_base
+++ b/docker/Dockerfile_base
@@ -41,7 +41,7 @@ RUN apt-get remove -y cmdtest && apt-get remove -y yarn && apt-get clean \
 && cd ./spec/dummy/ && npm install
 RUN cd ./
 
-# ALPINE DISTRO UPDATES NPM
+# ALPINE-UPDATES-NPM
 
 # this is used by the volume in docker-compose
 RUN mkdir -p /tmp/agent/messages

--- a/docker/Dockerfile_base
+++ b/docker/Dockerfile_base
@@ -34,11 +34,14 @@ RUN bundle config set with 'puma' 'thin'
 RUN bundle install
 
 # We need to run npm install or yarn install to be able to run mongoid in rails
-RUN apt-get remove -y cmdtest && apt-get remove -y yarn
-RUN curl -sL https://deb.nodesource.com/setup_16.x \
-    curl -fsSL https://dl.yarnpkg.com/debian/pubkey.gpg | gpg --dearmor -o /usr/share/keyrings/pubkey.gpg \
-    echo "deb [signed-by=/usr/share/keyrings/pubkey.gpg] https://dl.yarnpkg.com/debian/ stable main" | tee /etc/apt/sources.list.d/yarn.list \
-    apt-get update && apt-get install -y nodejs npm
+RUN apt-get remove -y cmdtest && apt-get remove -y yarn && apt-get clean \
+&& apt-get install -y curl software-properties-common \
+&& curl -sL https://deb.nodesource.com/setup_18.x | bash - \
+&& apt-get install -y nodejs && npm install -g npm@latest \
+&& cd ./spec/dummy/ && npm install
+RUN cd ./
+
+# ALPINE DISTRO UPDATES NPM
 
 # this is used by the volume in docker-compose
 RUN mkdir -p /tmp/agent/messages
@@ -51,7 +54,6 @@ ENV APP_LOG=/tmp/agent/app.log
 RUN bundle exec rake app:assets:precompile
 RUN bundle exec rails db:migrate
 
-RUN npm install spec/dummy/
 # Just in case, clean up local.
 RUN rm ./contrast_security.yaml ./spec/dummy/contrast_security.yaml || true
 RUN rm ./*log ./spec/dummy/*log || true


### PR DESCRIPTION
Changing the way NPM gets installed because of previous conflict for the `buster` distro of  `debian`. It appears that the slim image is getting not compatible versions of `nodejs` and `npm` installed, making running `npm` returning exceptions.

Most of this changes are rewritten and changed by the build script we use.