### PR TITLE
[RUBY-1645] Add Ruby 3.2

### DIFF
--- a/build_bases.sh
+++ b/build_bases.sh
@@ -6,7 +6,7 @@ SCRIPTNAME=$(basename "${BASH_SOURCE[0]}")
 APP_ROOT=$(dirname "${BASH_SOURCE[0]}")
 GIT_REPO=contrast-security-oss/vulneruby_engine
 
-RUBY_VERS="2.7 3 3.1"
+RUBY_VERS="2.7 3 3.1 3.2"
 
 
 usage() {


### PR DESCRIPTION
Add Ruby 3.2 to the ruby versions used when building base images.

I ran `bundle install` locally to see if any of the updated gems had changes specifically for Ruby 3.2. I didn't see any, so I've not committed any of those updates.