### PR TITLE
RUBY-Restore-Pipeline

### DIFF
--- a/app/controllers/vulneruby_engine/insecure_algorithm_controller.rb
+++ b/app/controllers/vulneruby_engine/insecure_algorithm_controller.rb
@@ -15,7 +15,8 @@ module VulnerubyEngine
       @result = {
           digest: Vulneruby::Trigger::CryptoBadMac.run_digest_md5,
           random: Vulneruby::Trigger::CryptoWeakRandomness.run_rand,
-          cipher: Vulneruby::Trigger::CryptoBadCipher.run_bad_cipher
+          # Bad Ciphers are deprecated in OpenSSL 3.X 
+          # cipher: Vulneruby::Trigger::CryptoBadCipher.run_bad_cipher
       }
 
       render('layouts/vulneruby_engine/insecure_algorithm/run')

--- a/docker/Dockerfile_agent
+++ b/docker/Dockerfile_agent
@@ -3,6 +3,12 @@ ARG RUBY_VER=3.0
 FROM ghcr.io/contrast-security-oss/vulneruby_engine/base:${RUBY_VER}
 
 ENV CI_TEST=true
+
+# If ruby is 3.0 then use ffi 1.15.5:
+RUN if [ "$RUBY_VER" = "3.0" ]; \
+    then echo "RUBY_VER is 3.0" && export CONTRAST__PIPELINE__RUN=true; \
+    fi
+
 COPY agent/* agent/
 RUN rm contrast_security.yaml || true
 COPY contrast_security.yaml contrast_security.yaml

--- a/docker/Dockerfile_base
+++ b/docker/Dockerfile_base
@@ -31,6 +31,14 @@ RUN gem install bundler
 ENV PUMA=true
 ENV THIN=true
 
+# If ruby is 3.0 then use ffi 1.15.5:
+RUN if [ "$RUBY_VER" = "3.0" ]; \
+    then echo "RUBY_VER is 3.0" && export CONTRAST__PIPELINE__RUN=true \
+    && bundle config build.ffi -- --disable-system-libffi \
+    && gem install ffi -v 1.15.5 -- -- disable-system-libffi; \
+    fi
+
+
 RUN bundle config set with 'puma' 'thin'
 RUN bundle config force_ruby_platform true \
     && bundle config build.nokogiri --use-system-libraries

--- a/docker/Dockerfile_passenger_max
+++ b/docker/Dockerfile_passenger_max
@@ -8,7 +8,7 @@ ENV PORT=$PORT_ARG
 ENV PASSENGER_MAX=true
 RUN bundle config set with 'passenger_max'
 
-RUN bundle update
+RUN bundle install
 
 # Copy configuration files to root directory:
 RUN cp /app/contrast_security.yaml /app/spec/dummy/contrast_security.yaml

--- a/docker/Dockerfile_passenger_min
+++ b/docker/Dockerfile_passenger_min
@@ -8,7 +8,7 @@ ENV PORT=$PORT_ARG
 ENV PASSENGER_MIN=true
 RUN bundle config set with 'passenger_min'
 
-RUN bundle update
+RUN bundle install
 
 # Copy configuration files to root directory:
 RUN cp /app/contrast_security.yaml /app/spec/dummy/contrast_security.yaml

--- a/docker/Dockerfile_puma_max
+++ b/docker/Dockerfile_puma_max
@@ -11,7 +11,7 @@ ENV WEB_CONCURRENCY=1
 ENV PUMA_MAX=true
 RUN bundle config set with 'puma_max'
 
-RUN bundle update
+RUN bundle install
 
 # So we may use whatever command we want to trigger rake, to be sure
 # that the agent is not braking the rake task

--- a/docker/Dockerfile_puma_min
+++ b/docker/Dockerfile_puma_min
@@ -11,7 +11,7 @@ ENV WEB_CONCURRENCY=1
 ENV PUMA_MIN=true
 RUN bundle config set with 'puma_min'
 
-RUN bundle update
+RUN bundle install
 
 # So we may use whatever command we want to trigger rake, to be sure
 # that the agent is not braking the rake task

--- a/docker/Dockerfile_thin_max
+++ b/docker/Dockerfile_thin_max
@@ -8,7 +8,7 @@ ENV PORT=$PORT_ARG
 ENV THIN_MAX=true
 RUN bundle config set with 'thin_max'
 
-RUN bundle update
+RUN bundle install
 
 # So we may use whatever command we want to trigger rake, to be sure
 # that the agent is not braking the rake task

--- a/docker/Dockerfile_thin_min
+++ b/docker/Dockerfile_thin_min
@@ -8,7 +8,7 @@ ENV PORT=$PORT_ARG
 ENV THIN_MIN=true
 RUN bundle config set with 'thin_min'
 
-RUN bundle update
+RUN bundle install
 
 # So we may use whatever command we want to trigger rake, to be sure
 # that the agent is not braking the rake task

--- a/docker/Dockerfile_unicorn_max
+++ b/docker/Dockerfile_unicorn_max
@@ -8,7 +8,7 @@ ENV PORT=$PORT_ARG
 ENV UNICORN_MAX=true
 RUN bundle config set with 'unicorn_max'
 
-RUN AGENT_PATH=`gem which contrast-agent` bundle update && bundle install
+RUN AGENT_PATH=`gem which contrast-agent` bundle install
 
 # So we may use whatever command we want to trigger rake, to be sure
 # that the agent is not braking the rake task

--- a/docker/Dockerfile_unicorn_min
+++ b/docker/Dockerfile_unicorn_min
@@ -8,7 +8,7 @@ ENV PORT=$PORT_ARG
 ENV UNICORN_MIN=true
 RUN bundle config set with 'unicorn_min'
 
-RUN AGENT_PATH=`gem which contrast-agent` bundle update && bundle install
+RUN AGENT_PATH=`gem which contrast-agent` bundle install
 
 # So we may use whatever command we want to trigger rake, to be sure
 # that the agent is not braking the rake task


### PR DESCRIPTION
- Updated `ffi` env settings for ruby 3.0
- Bad Ciphers are deprecated in OpenSSL 3.X  => ❌ Removed spec